### PR TITLE
Add support for require `minitest-stub-const'

### DIFF
--- a/lib/minitest/stub/const.rb
+++ b/lib/minitest/stub/const.rb
@@ -1,0 +1,1 @@
+require File.expand_path("../../stub_const", __FILE__)


### PR DESCRIPTION
When using this gem with Bundler one has to explicit require the gem or define a require path in the Gemfile.

Before:
```ruby
gem "minitest-stub-const", require: "minitest-stub_const"
```
After:
```ruby
gem "minitest-stub-const"
```