### PR TITLE
Add support for stubbing undefined constants

### DIFF
--- a/test/test_stub_const.rb
+++ b/test/test_stub_const.rb
@@ -31,6 +31,14 @@ describe 'Object' do
     it 'does not raise any warnings' do
       assert_silent { A.stub_const(:B, @mock) { } }
     end
+
+    it 'should stub undefined constants' do
+      refute defined?(A::X)
+      A.stub_const(:X, @mock) do
+        assert_equal :new, A::X.what
+      end
+      refute defined?(A::X)
+    end
   end
 
   describe '#stub_remove_const' do
@@ -47,6 +55,12 @@ describe 'Object' do
 
     it 'does not raise any warnings' do
       assert_silent { A.stub_remove_const(:B) { } }
+    end
+
+    it 'leaves undefined constants undefined' do
+      refute defined?(A::X)
+      A.stub_remove_const(:X) { }
+      refute defined?(A::X)
     end
   end
 end

--- a/test/test_stub_const.rb
+++ b/test/test_stub_const.rb
@@ -21,6 +21,7 @@ describe 'Object' do
       A.stub_const(:B, @mock) do
         assert_equal :new, A::B.what
       end
+      @mock.verify
     end
 
     it 'restores the original value after the block' do
@@ -38,6 +39,7 @@ describe 'Object' do
         assert_equal :new, A::X.what
       end
       refute defined?(A::X)
+      @mock.verify
     end
   end
 


### PR DESCRIPTION
This pull request adds support for stubbing undefined constants.

Typically, when I am stubbing a constant, I do so in order to ensure I know the current value in the context of a test. I do not usually care whether the constant is currently defined or not.

Having to add conditionals to my tests that check whether a constant is currently defined before stubbing it seems too cumbersome for me; hence this pull request.