### PR TITLE
Make stub_const example copy & pasteable

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,20 +7,55 @@ Like RSpec's [stub_const] [rspec], but boring and non-magical.
 
 
 ## Example
+Stub a constant for the duration of a block:
 
 ```ruby
-it "calls a Thing.add when add_thing is called" do
-  m = MiniTest::Mock.new
-  m.expect(:add, nil)
-  
-  MyLib.stub_const(:Thing, m) do
-    @subject.add_thing
-  end
-
-  m.verify
+module Foo
+  BAR = :original
 end
+
+Foo.stub_const(:BAR, :stubbed) do
+  Foo::BAR
+end
+# => :stubbed
+
+Foo::BAR
+# => :original
 ```
 
+This is especially useful when testing that the expected class methods
+are being called on a `Module` or `Class` instance:
+
+```ruby
+module SomeLib
+  class Thing
+    def self.add
+      fail NotImplementedError
+    end
+  end
+end
+
+class ThingAdder
+  def add_thing
+    SomeLib::Thing.add
+  end
+end
+
+describe ThingAdder do
+  describe '#add_thing' do
+    it 'should call Thing.add' do
+      adder = ThingAdder.new
+      mock = Minitest::Mock.new
+      mock.expect(:add, nil)
+
+      SomeLib.stub_const(:Thing, mock) do
+        adder.add_thing
+      end
+      assert mock.verify
+    end
+  end
+end
+```
 
 ## Installation
 

--- a/lib/minitest/stub_const.rb
+++ b/lib/minitest/stub_const.rb
@@ -1,21 +1,21 @@
 class Object
-
-  #
-  # Replace the +value+ of constant +name+ for the duration of a +block+. This
-  # is useful when testing that the expected class methods are being called on
-  # a Module or Class instance.
+  # Replace the +value+ of constant +name+ for the duration of a
+  # +block+. This is especially useful when testing that the expected
+  # class methods are being called on a Module or Class instance.
   #
   # Example:
   #
-  #   m = MiniTest::Mock.new
-  #   m.expect(:register, nil, [:whatever])
-  #
-  #   MyLib.stub_const(:Thing, m) do
-  #     @subject.add_thing(:whatever)
+  #   module Foo
+  #     BAR = :original
   #   end
-  #
-  #   m.verify
-  #
+  #   
+  #   Foo.stub_const(:BAR, :stubbed) do
+  #     Foo::BAR
+  #   end
+  #   # => :stubbed
+  #   
+  #   Foo::BAR
+  #   # => :original
   def stub_const(name, val, &block)
     defined = const_defined?(name)
     orig = const_get(name) if defined


### PR DESCRIPTION
Currently, the `stub_const` example cannot be run without changes. This pull request adds some boilerplate so that the example becomes runnable. (I tried not to change the basic idea of your original example too much.)

However, to be honest I am not quite sure if this is the right way to show off the functionality of `stub_const` in the docs. Maybe such an elaborate example should only be shown in the README and the code example should be something really simple like this?

```ruby
module Foo
  BAR = :original
end

Foo.stub_const(:BAR, :stubbed) do
  Foo::BAR
end
# => :stubbed

Foo::BAR
# => :original
```

Would you be open to such a change?