### PR TITLE
add support for stubbing multiple constants simultaneously

### DIFF
--- a/lib/minitest/stub_const.rb
+++ b/lib/minitest/stub_const.rb
@@ -8,24 +8,54 @@ class Object
   #   module Foo
   #     BAR = :original
   #   end
-  #   
+  #
   #   Foo.stub_const(:BAR, :stubbed) do
   #     Foo::BAR
   #   end
   #   # => :stubbed
-  #   
+  #
   #   Foo::BAR
   #   # => :original
-  def stub_const(name, val, &block)
-    defined = const_defined?(name)
-    orig = const_get(name) if defined
-    silence_warnings { const_set(name, val) }
+  def stub_const(name, val = nil, &block)
+    stub_consts(name => val, &block)
+  end
+
+  # Same as stub_const except it supports a Hash of +name+ to +value+ pairs
+  # of the constants that will be stubbed for the duration of the +block+.
+  #
+  # Example:
+  #
+  #   module Foo
+  #     BAR = :original1
+  #     BAZ = :original2
+  #   end
+  #
+  #   Foo.stub_consts(BAR: :stubble, BAZ: :stubby) do
+  #     [Foo::BAR, Foo::BAZ]
+  #   end
+  #   # => [:stubble, :stubby]
+  #
+  #   [Foo::BAR, Foo::BAZ]
+  #   # => [:original1, :original2]
+  def stub_consts(consts, &block)
+    original_values = {}
+    consts.each_pair do |name, val|
+      if const_defined?(name)
+        original_value = const_get(name)
+        original_values[name] = original_value
+      end
+      silence_warnings { const_set(name, val) }
+    end
+
     yield
+
   ensure
-    if defined
-      silence_warnings { const_set(name, orig) }
-    else
-      remove_const(name)
+    consts.keys.each do |name|
+      if original_values.key?(name)
+        silence_warnings { const_set(name, original_values[name]) }
+      else
+        remove_const(name)
+      end
     end
   end
 

--- a/test/test_stub_const.rb
+++ b/test/test_stub_const.rb
@@ -8,6 +8,12 @@ module A
       :old
     end
   end
+
+  module C
+    def self.who
+      :you
+    end
+  end
 end
 
 describe 'Object' do
@@ -63,6 +69,48 @@ describe 'Object' do
       refute defined?(A::X)
       A.stub_remove_const(:X) { }
       refute defined?(A::X)
+    end
+  end
+
+  describe '#stub_consts' do
+    before do
+      @mock = MiniTest::Mock.new
+      @mock.expect(:what, :new)
+
+      @mock2 = MiniTest::Mock.new
+      @mock2.expect(:who, :me)
+
+      @mock3 = MiniTest::Mock.new
+      @mock3.expect(:where, :there)
+    end
+
+    def run_stub_block
+      A.stub_consts(B: @mock, C: @mock2, D: @mock3) do
+        assert_equal :new, A::B.what
+        assert_equal :me, A::C.who
+        assert_equal :there, A::D.where
+      end
+    end
+
+    it 'replaces a set of constants for the duration of a block' do
+      run_stub_block
+
+      @mock.verify
+      @mock2.verify
+      @mock3.verify
+    end
+
+    it 'restores previous values' do
+      run_stub_block
+
+      assert_equal :old, A::B.what
+      assert_equal :you, A::C.who
+    end
+
+    it 'removes constants that were undefined prior to the block' do
+      run_stub_block
+
+      refute A.const_defined?(:D)
     end
   end
 end


### PR DESCRIPTION
Hi there!

I ran into a case where I needed to stub two constants in the same module recently. To facilitate this, I needed to do the following:

```ruby
module A
  FOO = :original1
  BAR = :original2
end

A.stub_const(:FOO, :stubbed) do
  A.stub_const(:BAR, :also_stubbed) do
    # test code
  end
end
```

I felt this was too much nesting, so I extracted the logic from `stub_const` into a new `stub_consts` method which takes a hash of constants to stubbed values. So the above example becomes:

```ruby
A.stub_consts(FOO: :stubbed, BAR: :also_stubbed) do
  # test code
end
```

I hope you find this useful and will consider merging this change. Thanks for taking a look at this PR and also thanks for writing this library!