### PR TITLE
Fix compatibility with Minitest 5.19+.

### DIFF
--- a/test/test_stub_const.rb
+++ b/test/test_stub_const.rb
@@ -19,7 +19,7 @@ end
 describe 'Object' do
   describe '#stub_const' do
     before do
-      @mock = MiniTest::Mock.new
+      @mock = Minitest::Mock.new
       @mock.expect(:what, :new)
     end
 
@@ -74,13 +74,13 @@ describe 'Object' do
 
   describe '#stub_consts' do
     before do
-      @mock = MiniTest::Mock.new
+      @mock = Minitest::Mock.new
       @mock.expect(:what, :new)
 
-      @mock2 = MiniTest::Mock.new
+      @mock2 = Minitest::Mock.new
       @mock2.expect(:who, :me)
 
-      @mock3 = MiniTest::Mock.new
+      @mock3 = Minitest::Mock.new
       @mock3.expect(:where, :there)
     end
 


### PR DESCRIPTION
This fixes errors such as:

~~~
  1) Error:
Object::#stub_consts#test_0001_replaces a set of constants for the duration of a block:
NameError: uninitialized constant MiniTest
    /builddir/build/BUILD/minitest-stub-const-0.6/usr/share/gems/gems/minitest-stub-const-0.6/test/test_stub_const.rb:77:in `block (3 levels) in <top (required)>'
~~~

However, this also means that the test suite now requires Mintest 5+. It should have no impact on runtime support of older Minitests.